### PR TITLE
Remove the postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "update": "npm i punycode superagent && node ./scripts/update.js",
     "pretest": "npm run update",
     "test": "node ./scripts/test",
-    "prepublish": "npm test",
-    "postinstall": "npm test"
+    "prepublish": "npm test"
   },
   "keywords": [
     "tld",


### PR DESCRIPTION
It makes a network request, which can fail and break `npm install`.